### PR TITLE
Add base class contract to renders

### DIFF
--- a/rsoccer_gym/Render/BaseRender.py
+++ b/rsoccer_gym/Render/BaseRender.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from rsoccer_gym.Entities import Frame, Field
+from rsoccer_gym.Entities import Frame
 
 class BaseRender(ABC):
     @abstractmethod
@@ -30,8 +29,3 @@ class BaseRender(ABC):
     @abstractmethod
     def _add_ball() -> None:
         pass
-
-@dataclass
-class RenderParam2D:
-    DEFAULT_WIDTH: int = 1080
-    DEFAULT_HEIGHT: int = 720

--- a/rsoccer_gym/Render/BaseRender.py
+++ b/rsoccer_gym/Render/BaseRender.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from rsoccer_gym.Entities import Frame, Field
+
+class BaseRender(ABC):
+    @abstractmethod
+    def __del__(self):
+        pass
+
+    @abstractmethod
+    def render_frame(self, frame: Frame, return_rgb_array: bool = False) -> None:
+        pass
+
+    @abstractmethod
+    def _add_background(self) -> None:
+        pass
+
+    @abstractmethod
+    def _add_field_lines(self) -> None:
+        pass
+
+    @abstractmethod
+    def _add_multiple_agents(self) -> None:
+        pass
+
+    @abstractmethod
+    def _add_agent(self) -> None:
+        pass
+
+    @abstractmethod
+    def _add_ball() -> None:
+        pass
+
+@dataclass
+class RenderParam2D:
+    DEFAULT_WIDTH: int = 1080
+    DEFAULT_HEIGHT: int = 720

--- a/rsoccer_gym/Render/Render2D.py
+++ b/rsoccer_gym/Render/Render2D.py
@@ -21,7 +21,24 @@ class Render2D(BaseRender):
         self.field_params: Final[Field] = field_params
 
         # todo(bonna.borsoi): implement required params to render
-        self.screen_dimensions = None
+
+        margin = 40.0
+        goal_width = 146.56
+        goal_length = 44
+        pitch_length = 840
+        pitch_width = 544 
+
+        # half dimensions
+        h_length = (pitch_length + 2*goal_length) / 2
+        h_width = pitch_width / 2
+
+        self.screen_dimensions = {
+            "left" : -(h_length + margin),
+            "right" : (h_length + margin),
+            "bottom" : -(h_width + margin),
+            "top" : (h_width + margin),
+        }
+
         self.screen = None
 
         self._add_background()

--- a/rsoccer_gym/Render/Render2D.py
+++ b/rsoccer_gym/Render/Render2D.py
@@ -1,0 +1,48 @@
+from dataclasses import Field
+from typing import Final
+from rsoccer_gym.Render.BaseRender import BaseRender, RenderParam2D
+
+class Render2D(BaseRender):
+    def __init__(self, n_allies: int,
+                 n_adversaries: int,
+                 field_params: Field,
+                 width: float = RenderParam2D.DEFAULT_WIDTH,
+                 height: float = RenderParam2D.DEFAULT_HEIGHT) -> None:
+        '''
+        Docstrings to write.
+        '''
+        self.n_allies: Final[int] = n_allies
+        self.n_adversaries: Final[int] = n_adversaries
+        self.field_params: Final[Field] = field_params
+
+        # todo(bonna.borsoi): implement required params to render
+        self.screen_dimensions = None
+        self.screen = None
+
+        self._add_background()
+        self._add_field_lines()
+        self._add_multiple_agents()
+        self._add_ball()
+
+    def __del__(self):
+        self.screen.close()
+        del(self.screen)
+        self.screen = None
+
+    def render_frame(self) -> None:
+        raise NotImplementedError
+    
+    def _add_background(self) -> None:
+        raise NotImplementedError
+
+    def _add_field_lines(self) -> None:
+        raise NotImplementedError
+
+    def _add_multiple_agents(self) -> None:
+        raise NotImplementedError
+    
+    def _add_agent(self) -> None:
+        raise NotImplementedError
+    
+    def _add_ball() -> None:
+        raise NotImplementedError

--- a/rsoccer_gym/Render/Render2D.py
+++ b/rsoccer_gym/Render/Render2D.py
@@ -1,6 +1,11 @@
-from dataclasses import Field
+from dataclasses import Field, dataclass
 from typing import Final
 from rsoccer_gym.Render.BaseRender import BaseRender, RenderParam2D
+
+@dataclass
+class RenderParam2D:
+    DEFAULT_WIDTH: int = 1080
+    DEFAULT_HEIGHT: int = 720
 
 class Render2D(BaseRender):
     def __init__(self, n_allies: int,


### PR DESCRIPTION
This change adds a base `BaseRender` class to new renders override implementation. It is intended to provide extensibility from the already created rendering algorithms implemented in the library.

- Adds `BaseRender` class to be followed by newly added renders.
- Adds `Render2D` to implement Robocup Soccer Simulation 2D rendering objects.
- Adds `RenderParam2D` dataclass as a param aggregator from `Render2D` class.
 