### PR TITLE
Fix Install Requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name='rsoccer-gym',
     url="https://github.com/robocin/rSoccer",
     description="SSL and VSS robot soccer gym environments",
     packages=[package for package in find_packages() if package.startswith("rsoccer_gym")],
-    install_requires=['gym==0.21.0', 'rc-robosim>=1.2.0', 'pyglet', 'protobuf']
+    install_requires=['gym==0.21.0', 'rc-robosim==1.2.0', 'pyglet==1.5.27', 'protobuf==3.20']
 )


### PR DESCRIPTION
Set explicit pyglet version to 1.5.27 to fix the error:
``NameError: name 'glPushMatrix' is not defined``

based on https://stackoverflow.com/questions/74314778/nameerror-name-glpushmatrix-is-not-defined solution

Set protobuf version to 3.20 based on the following error:
```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

With this changes, the repo should work as instructed with the ``pip install -e .`` command
